### PR TITLE
Use multiple replacements instead of a single complex regex

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,23 +1,15 @@
 'use strict';
 
-const escapes = new Map([
-	['&', '&amp;'],
-	['<', '&lt;'],
-	['>', '&gt;'],
-	['"', '&quot;'],
-	['\'', '&#39;']
-]);
+exports.escape = input => input
+	.replace(/&/g, '&amp;')
+	.replace(/"/g, '&quot;')
+	.replace(/'/g, '&#39;')
+	.replace(/</g, '&lt;')
+	.replace(/>/g, '&gt;');
 
-const unescapes = new Map([
-	['&amp;', '&'],
-	['&lt;', '<'],
-	['&gt;', '>'],
-	['&quot;', '"'],
-	['&#39;', '\'']
-]);
-
-exports.escape = input =>
-	input.replace(/[&<>"']/g, m => escapes.get(m) || m);
-
-exports.unescape = input =>
-	input.replace(/&(?:amp|lt|gt|quot|#39);/g, m => unescapes.get(m) || m);
+exports.unescape = input => input
+	.replace(/&amp;/g, '&')
+	.replace(/&quot;/g, '"')
+	.replace(/&#39;/g, '\'')
+	.replace(/&lt;/g, '<')
+	.replace(/&gt;/g, '>');


### PR DESCRIPTION
It may seem counter-intuitive but... in my case this version outperforms the current version (and the one in #1), probably because it doesn't have to run a custom function on every replacement.

Rough test with:

```sh
curl https://en.wikipedia.org/wiki/Unicorn > html
node -e "const eg = require('.');\
         const html = fs.readFileSync('html', 'utf-8');\
         console.time('a');\
         for(var i = 0; i < 100; i++) \
         eg.escape(html);\
         console.timeEnd('a');"
a: 225.440ms # currently on master
a: 213.930ms # PR #1
a: 189.726ms # PR #2 (this)
```

A Chrome console also test shows a 600ms -> 300ms duration change.

Edit: adding `html = html.substr(0, 100)` brings greater changes too: 1.724ms -> 0.857ms