### PR TITLE
Add support for unescaping non-breaking space entity

### DIFF
--- a/index.js
+++ b/index.js
@@ -12,4 +12,5 @@ exports.unescape = input => input
 	.replace(/&quot;/g, '"')
 	.replace(/&#39;/g, '\'')
 	.replace(/&lt;/g, '<')
-	.replace(/&gt;/g, '>');
+	.replace(/&gt;/g, '>')
+	.replace(/&nbsp;/g, ' ');

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "escape-goat",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "description": "Escape a string for use in HTML or the inverse",
   "license": "MIT",
   "repository": "sindresorhus/escape-goat",

--- a/readme.md
+++ b/readme.md
@@ -38,7 +38,7 @@ Escapes the following characters in the given `input` string: `&` `<` `>` `"` `'
 
 ### escapeGoat.unescape(html)
 
-Unescapes the following HTML entities in the given `input` string: `&amp;` `&lt;` `&gt;` `&quot;` `&#39;`
+Unescapes the following HTML entities in the given `input` string: `&amp;` `&lt;` `&gt;` `&quot;` `&#39;` `&nbsp;`
 
 
 ## Tip

--- a/test.js
+++ b/test.js
@@ -10,7 +10,7 @@ test('escape', t => {
 test('unescape', t => {
 	t.is(m.unescape('&amp;&lt;&gt;&quot;&#39;'), '&<>"\'');
 	t.is(m.unescape('🦄 &amp; 🐐'), '🦄 & 🐐');
-	t.is(m.unescape('Hello &lt;em&gt;World&lt;/em&gt;'), 'Hello <em>World</em>');
+	t.is(m.unescape('Hello&nbsp;&lt;em&gt;World&lt;/em&gt;'), 'Hello <em>World</em>');
 });
 
 test('escape & unescape', t => {


### PR DESCRIPTION
While a `&nbsp;` (non-breaking space entity) is quite common in my use case;
It will be really helpful to support `&nbsp;` unescaping to me.

(And it's also listed on the top of the HTML entities table from w3schools: https://www.w3schools.com/html/html_entities.asp)

While `&nbsp;` can be unescaped into whitespace, but whitespace shouldn't be escaped into `&nbsp;` because [they behaves different](https://en.wikipedia.org/wiki/Non-breaking_space).

Hope this helps!