### PR TITLE
Accept non-strings in `htmlEscapeTag` and `htmlUnescapeTag`

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,13 +1,13 @@
 'use strict';
 
-exports.htmlEscape = string => String(string)
+exports.htmlEscape = string => string
 	.replace(/&/g, '&amp;')
 	.replace(/"/g, '&quot;')
 	.replace(/'/g, '&#39;')
 	.replace(/</g, '&lt;')
 	.replace(/>/g, '&gt;');
 
-exports.htmlUnescape = htmlString => String(htmlString)
+exports.htmlUnescape = htmlString => htmlString
 	.replace(/&gt;/g, '>')
 	.replace(/&lt;/g, '<')
 	.replace(/&#39;/g, '\'')
@@ -17,7 +17,7 @@ exports.htmlUnescape = htmlString => String(htmlString)
 exports.htmlEscapeTag = (strings, ...values) => {
 	let output = strings[0];
 	for (let i = 0; i < values.length; i++) {
-		output = output + exports.htmlEscape(values[i]) + strings[i + 1];
+		output = output + exports.htmlEscape(String(values[i])) + strings[i + 1];
 	}
 
 	return output;
@@ -26,7 +26,7 @@ exports.htmlEscapeTag = (strings, ...values) => {
 exports.htmlUnescapeTag = (strings, ...values) => {
 	let output = strings[0];
 	for (let i = 0; i < values.length; i++) {
-		output = output + exports.htmlUnescape(values[i]) + strings[i + 1];
+		output = output + exports.htmlUnescape(String(values[i])) + strings[i + 1];
 	}
 
 	return output;

--- a/index.js
+++ b/index.js
@@ -1,13 +1,13 @@
 'use strict';
 
-exports.htmlEscape = string => string
+exports.htmlEscape = string => String(string)
 	.replace(/&/g, '&amp;')
 	.replace(/"/g, '&quot;')
 	.replace(/'/g, '&#39;')
 	.replace(/</g, '&lt;')
 	.replace(/>/g, '&gt;');
 
-exports.htmlUnescape = htmlString => htmlString
+exports.htmlUnescape = htmlString => String(htmlString)
 	.replace(/&gt;/g, '>')
 	.replace(/&lt;/g, '<')
 	.replace(/&#39;/g, '\'')

--- a/test.js
+++ b/test.js
@@ -24,7 +24,7 @@ test('htmlEscapeTag', t => {
 	t.is(htmlEscapeTag`Hello <em><>${'<>'}</em>`, 'Hello <em><>&lt;&gt;</em>');
 });
 
-test.failing('htmlEscapeTag non-strings', t => {
+test('htmlEscapeTag non-strings', t => {
 	t.is(htmlEscapeTag`foobarz${undefined}`, 'foobarzundefined');
 	t.is(htmlEscapeTag`🦄 ${true}`, '🦄 true');
 	t.is(htmlEscapeTag`Hello <em><>${1}</em>`, 'Hello <em><>1</em>');
@@ -36,7 +36,7 @@ test('htmlUnescapeTag', t => {
 	t.is(htmlUnescapeTag`Hello <em><>${'&lt;&gt;'}</em>`, 'Hello <em><><></em>');
 });
 
-test.failing('htmlUnescapeTag non-strings', t => {
+test('htmlUnescapeTag non-strings', t => {
 	t.is(htmlUnescapeTag`foobarz${undefined}`, 'foobarzundefined');
 	t.is(htmlUnescapeTag`🦄 ${true}`, '🦄 true');
 	t.is(htmlUnescapeTag`Hello <em><>${1}</em>`, 'Hello <em><>1</em>');

--- a/test.js
+++ b/test.js
@@ -24,10 +24,22 @@ test('htmlEscapeTag', t => {
 	t.is(htmlEscapeTag`Hello <em><>${'<>'}</em>`, 'Hello <em><>&lt;&gt;</em>');
 });
 
+test.failing('htmlEscapeTag non-strings', t => {
+	t.is(htmlEscapeTag`foobarz${undefined}`, 'foobarz');
+	t.is(htmlEscapeTag`🦄 ${true}`, '🦄 ');
+	t.is(htmlEscapeTag`Hello <em><>${1}</em>`, 'Hello <em><>1</em>');
+});
+
 test('htmlUnescapeTag', t => {
 	t.is(htmlUnescapeTag`foobarz${'&amp;&lt;&gt;&quot;&#39;'}`, 'foobarz&<>"\'');
 	t.is(htmlUnescapeTag`🦄 ${'&amp;'} 🐐`, '🦄 & 🐐');
 	t.is(htmlUnescapeTag`Hello <em><>${'&lt;&gt;'}</em>`, 'Hello <em><><></em>');
+});
+
+test.failing('htmlUnescapeTag non-strings', t => {
+	t.is(htmlUnescapeTag`foobarz${undefined}`, 'foobarz');
+	t.is(htmlUnescapeTag`🦄 ${true}`, '🦄 ');
+	t.is(htmlUnescapeTag`Hello <em><>${1}</em>`, 'Hello <em><>1</em>');
 });
 
 test('htmlEscapeTag & htmlUnescapeTag', t => {

--- a/test.js
+++ b/test.js
@@ -25,8 +25,8 @@ test('htmlEscapeTag', t => {
 });
 
 test.failing('htmlEscapeTag non-strings', t => {
-	t.is(htmlEscapeTag`foobarz${undefined}`, 'foobarz');
-	t.is(htmlEscapeTag`🦄 ${true}`, '🦄 ');
+	t.is(htmlEscapeTag`foobarz${undefined}`, 'foobarzundefined');
+	t.is(htmlEscapeTag`🦄 ${true}`, '🦄 true');
 	t.is(htmlEscapeTag`Hello <em><>${1}</em>`, 'Hello <em><>1</em>');
 });
 
@@ -37,8 +37,8 @@ test('htmlUnescapeTag', t => {
 });
 
 test.failing('htmlUnescapeTag non-strings', t => {
-	t.is(htmlUnescapeTag`foobarz${undefined}`, 'foobarz');
-	t.is(htmlUnescapeTag`🦄 ${true}`, '🦄 ');
+	t.is(htmlUnescapeTag`foobarz${undefined}`, 'foobarzundefined');
+	t.is(htmlUnescapeTag`🦄 ${true}`, '🦄 true');
 	t.is(htmlUnescapeTag`Hello <em><>${1}</em>`, 'Hello <em><>1</em>');
 });
 


### PR DESCRIPTION
Real life example:

```js
const fields = {}; // Object comes from contact form
htmlEscapeTag`Phone: ${fields.phone}`;
```

I would say: 
- strings and numbers: `String(value)`
- everything else: `''`